### PR TITLE
Minor changes

### DIFF
--- a/src/lib/components/carousel.svelte
+++ b/src/lib/components/carousel.svelte
@@ -4,15 +4,9 @@
 	import { browser } from '$app/environment'
 	import '$scss/components/carousel.scss'
 
-	const autoplayDuration = 7 * 1000 // ms
+	export let autoplayDuration = 7 * 1000 // ms
 	const duration = 1 * 1000 // ms
-	const MEDIUM_DEVICE_WIDTH = 768 // _shared.scss
-
-	let innerWidth: number = 0
-	$: isMediumDevice = innerWidth <= MEDIUM_DEVICE_WIDTH ? true : false
 </script>
-
-<svelte:window bind:innerWidth />
 
 {#if browser}
 	<Carousel
@@ -20,7 +14,7 @@
 		let:showNextPage
 		autoplay={true}
 		pauseOnFocus={true}
-		dots={isMediumDevice}
+		dots={true}
 		{autoplayDuration}
 		{duration}
 	>

--- a/src/lib/components/messages-container.svelte
+++ b/src/lib/components/messages-container.svelte
@@ -3,6 +3,8 @@
 	import { page } from '$app/stores'
 	import { Toast } from '$components'
 	import type { Message } from '$types'
+	import { generateMessages } from '../utils'
+	import { afterNavigate } from '$app/navigation'
 
 	$: base_messages = ($page.form?.messages as Message[]) ?? []
 	let messages: Message[] = []
@@ -16,12 +18,33 @@
 		base_messages.forEach((msg) => {
 			messages.push({
 				...msg,
-				delay: accumulated_period
+				delay: accumulated_period,
+				duration:  msg.duration + accumulated_period
 			})
 			accumulated_period += delay_period
 		})
 		messages = [...messages]
 	}
+
+	// remove this code when real data comes in
+	afterNavigate(() => {
+		const nilUUID = '00000000-0000-0000-0000-000000000000'
+		const fictitiousDataAlertMessage = generateMessages([
+			{
+				id: 0,
+				message: 'Os dados deste campo missionário são fictícios e apenas para demonstração',
+				variant: 'info',
+				duration: 60 * 60 * 1000 // 1 hour in ms
+			}
+		])
+
+		const isFictitiousDataPage = $page.params?.id ? $page.params?.id == nilUUID : false
+		if (isFictitiousDataPage && !messages.some((msg) => msg.id == 0)) {
+			messages = [...messages, ...fictitiousDataAlertMessage]
+		} else if (!isFictitiousDataPage) {
+			messages = []
+		}
+	})
 </script>
 
 <div class="messages-container">

--- a/src/lib/components/search-offeror-family.svelte
+++ b/src/lib/components/search-offeror-family.svelte
@@ -21,7 +21,8 @@
 		{#if offerorFamilies.length > 0}
 			{#each offerorFamilies as offerorFamily (offerorFamily.id)}
 				<div class="data-item">
-					<span class="representative">{offerorFamily.representative}</span>
+					<span class="family">{offerorFamily.familyName}</span>
+					<span class="representative">representada por: {offerorFamily.representative}</span>
 					{#if offerorFamily.chuchDenomination}
 						<span class="church">Igreja: {offerorFamily.chuchDenomination}</span>
 					{/if}

--- a/src/lib/components/testimonial.svelte
+++ b/src/lib/components/testimonial.svelte
@@ -4,12 +4,13 @@
 	import Carousel from './carousel.svelte'
 
 	export let testimonials: TestimonialDto[]
+	const autoplayDuration = 15 * 1000 // ms
 </script>
 
 <section id="testimonials">
 	<h1>Testemunhos</h1>
 	{#if testimonials?.length > 0}
-		<Carousel>
+		<Carousel {autoplayDuration}>
 			{#each testimonials as testimonial (testimonial.id)}
 				<div class="testimonial">
 					<div class="content">

--- a/src/lib/components/toast.svelte
+++ b/src/lib/components/toast.svelte
@@ -13,7 +13,7 @@
 
 	export let isOpen = true
 	export let autoHide = true
-	export let duration = 5 // in seconds
+	export let duration = 5 * 1000 // in ms
 	export let delay = 0 // in ms
 
 	onMount(async () => {
@@ -32,7 +32,7 @@
 	if (autoHide) {
 		setTimeout(() => {
 			close()
-		}, duration * 1000)
+		}, duration)
 	}
 </script>
 

--- a/src/lib/components/volunteer.svelte
+++ b/src/lib/components/volunteer.svelte
@@ -44,8 +44,8 @@
 		<p class="sub-title no-text-indent">{occupations.filter((occ) => occ.value == volunteer.occupation)[0].text}</p>
 	</div>
 	<div class="body">
-		<span class="church">{volunteer.church}</span>
-		<span class="priest">{volunteer.priest}</span>
-		<span class="joined-date">Desde: {new Date(volunteer.joinedDate).toLocaleDateString()}</span>
+		{#if volunteer.church}<span class="church">Igreja: {volunteer.church}</span>{/if}
+		{#if volunteer.priest}<span class="priest">Pastor: {volunteer.priest}</span>{/if}
+		<span class="joined-date">Desde: {new Date(volunteer.joinedDate).toLocaleDateString('pt-BR')}</span>
 	</div>
 </div>

--- a/src/lib/constants/labels/offeror-family-group.ts
+++ b/src/lib/constants/labels/offeror-family-group.ts
@@ -1,5 +1,5 @@
 export const OFFEROR_FAMILY_GROUP = {
-	church: 'igreja',
-	community: 'comunidade',
-	external: 'externo'
+	church: 'Igreja',
+	community: 'Comunidade',
+	external: 'Externo'
 }

--- a/src/lib/scss/components/search-offeror-family.scss
+++ b/src/lib/scss/components/search-offeror-family.scss
@@ -22,7 +22,7 @@
 	margin-bottom: 0.2rem;
 	box-shadow: 0.2rem 0.2rem 0.3rem lightgray;
 
-	.representative {
+	.family {
 		font-size: 1.2rem;
 
 		a {
@@ -33,6 +33,7 @@
 		}
 	}
 
+	.representative,
 	.commitment,
 	.group,
 	.church {

--- a/src/lib/scss/components/volunteer.scss
+++ b/src/lib/scss/components/volunteer.scss
@@ -50,7 +50,8 @@
 
 		p {
 			font-size: 0.8rem;
-			margin-bottom: 0.2rem;
+			margin-bottom: 0rem;
+			opacity: 1;
 		}
 	}
 
@@ -60,13 +61,10 @@
 		display: flex;
 		flex-direction: column;
 
-		.church {
-			font-size: 1rem;
-		}
-
 		.priest,
-		.joined-date {
-			font-size: 0.8rem;
+		.joined-date, 
+		.church {
+			font-size: .8rem;
 			opacity: 0.8;
 		}
 	}

--- a/src/lib/scss/global.scss
+++ b/src/lib/scss/global.scss
@@ -142,6 +142,10 @@ h3 {
 	h1 {
 		font-size: var(--h1-font-size);
 		margin-bottom: 0;
+
+		+ h3.pages {
+			opacity: 0.6;
+		}
 	}
 
 	h2 {

--- a/src/lib/scss/routes/fields/reports.scss
+++ b/src/lib/scss/routes/fields/reports.scss
@@ -48,3 +48,11 @@
 		}
 	}
 }
+
+.text-placeholder {
+	width: 100%;
+
+	p {
+		text-align: center;
+	}
+}

--- a/src/lib/types/dto/offeror-family.dto.ts
+++ b/src/lib/types/dto/offeror-family.dto.ts
@@ -3,6 +3,7 @@ import type { FieldDto } from './field.dto'
 
 export type OfferorFamilyDto = {
 	id: string
+	familyName: string
 	representative: string
 	commitment: string
 	chuchDenomination?: string

--- a/src/lib/types/dto/welcomed-family.dto.ts
+++ b/src/lib/types/dto/welcomed-family.dto.ts
@@ -2,6 +2,7 @@ import type { FieldDto } from './field.dto'
 
 export type WelcomedFamilyDto = {
 	id: string
+	familyName: string
 	representative: string
 	observation: string
 

--- a/src/lib/types/message.ts
+++ b/src/lib/types/message.ts
@@ -3,6 +3,6 @@ export type Message = {
 	message: string
 	variant: 'danger' | 'success' | 'info'
 	silent?: boolean
-	duration?: number
+	duration: number
 	delay?: number
 }

--- a/src/lib/utils/generate-messages.ts
+++ b/src/lib/utils/generate-messages.ts
@@ -1,19 +1,22 @@
 import type { Message } from '../types'
 
 type generateMessagesOptions = {
+	id?: number
 	message: string
 	variant?: 'danger' | 'success' | 'info'
 	silent?: boolean
+	duration?: number
 }
 
 export function generateMessages(messages: generateMessagesOptions[]) {
 	return messages.map(
 		(msg) =>
 			({
-				id: Math.floor(Math.random() * Date.now()),
+				id: msg.id ?? Math.floor(Math.random() * Date.now()),
 				message: msg.message,
 				variant: msg.variant ?? 'danger',
-				silent: msg.silent ?? false
+				silent: msg.silent ?? false,
+				duration: msg.duration ?? 5 * 1000 // default value from toast.svelte
 			} as Message)
 	)
 }

--- a/src/routes/(breadcrumbs)/fields/[id=id]/reports/+page.svelte
+++ b/src/routes/(breadcrumbs)/fields/[id=id]/reports/+page.svelte
@@ -71,4 +71,8 @@
 	{#each annualReports as report}
 		<Report {report} />
 	{/each}
+{:else}
+	<div class="text-placeholder">
+		<p>Ainda não foi registrada nenhum relatório.</p>
+	</div>
 {/if}

--- a/src/routes/(breadcrumbs)/fields/[id=id]/welcomed-families/+page.svelte
+++ b/src/routes/(breadcrumbs)/fields/[id=id]/welcomed-families/+page.svelte
@@ -14,8 +14,8 @@
 	{#if welcomedFamilies.length > 0}
 		{#each welcomedFamilies as welcomedFamily (welcomedFamily.id)}
 			<div class="welcomed-family">
-				<div class="family">{welcomedFamily.representative}</div>
-				<div class="family-sub">Família representada por</div>
+				<div class="family">{welcomedFamily.familyName}</div>
+				<div class="family-sub">Família representada por {welcomedFamily.representative}</div>
 			</div>
 		{/each}
 	{:else}


### PR DESCRIPTION
refactor:
	(carousel.svelte) exporting autoplayDuration and dots is always visible
	(messages-container.svelte) info message for fictitious data
	(testimonial.svelte) long duration on each testimonial (15s)
	(toast.svelte) duration in ms (instead of seconds, one unit only to all time variables)
	(volunteer.svelte) checking optional data before printing in class="body"
	(repors page) placeholder text
	added familyName to WelcomedFamily and OfferorFamily DTOs
	(generate-messages.ts) id and duration options with default values